### PR TITLE
Feat: MapSerializer handle correctly with IEnumerable of strings.

### DIFF
--- a/src/MapSerializer.Test/MapJsonSerializerTests.cs
+++ b/src/MapSerializer.Test/MapJsonSerializerTests.cs
@@ -229,5 +229,23 @@ namespace MapSerializer.Test
             serializedContent.Should().Be(sampleSerialization);
         }
 
+        [Fact]
+        public void MapJsonSerializer_MustSerialize_IEnumerableOfInt()
+        {
+            //SETUP
+            var instance = new TypeWithIEnumerableOfPrimitiveTypesProperty() { ListOfIntegers = new List<int> { 1,2,3 } };
+            var sampleSerialization = ComparisonSerializer.SerializeToJson(instance);
+
+            this.serializer.MapType<TypeWithIEnumerableOfPrimitiveTypesProperty>().MapProperty(p => p.ListOfIntegers);
+
+            //ACTION
+            this.serializer.Serialize(writer,instance);
+            var serializedContent = writer.ToString();
+
+            //CHECK
+            serializedContent.Should().Be(sampleSerialization);
+        }
+
+
     }
 }

--- a/src/MapSerializer.Test/MapJsonSerializerTests.cs
+++ b/src/MapSerializer.Test/MapJsonSerializerTests.cs
@@ -212,5 +212,22 @@ namespace MapSerializer.Test
             serializedContent.Should().Be(sampleSerialization);
         }
 
+        [Fact]
+        public void MapJsonSerializer_MustSerialize_StringsWithoutSplitThem()
+        {
+            //SETUP
+            var instance = new TypeWithEnumerableOfStringProperty() { ListProperty = new List<string> { "Value 1", "Value 2", "Value 3" } };
+            var sampleSerialization = ComparisonSerializer.SerializeToJson(instance);
+
+            this.serializer.MapType<TypeWithEnumerableOfStringProperty>().MapProperty(p => p.ListProperty);
+
+            //ACTION
+            this.serializer.Serialize(writer,instance);
+            var serializedContent = writer.ToString();
+
+            //CHECK
+            serializedContent.Should().Be(sampleSerialization);
+        }
+
     }
 }

--- a/src/MapSerializer.Test/MapXmlSerializerTests.cs
+++ b/src/MapSerializer.Test/MapXmlSerializerTests.cs
@@ -234,5 +234,23 @@ namespace MapSerializer.Test
             //CHECK
             serializedContent.Should().Be(sampleSerialization);
         }
+
+        [Fact]
+        public void MapXmlSerializer_MustSerialize_IEnumerableOfInt()
+        {
+            //SETUP
+            var instance = new TypeWithIEnumerableOfPrimitiveTypesProperty() { ListOfIntegers = new List<int> { 1,2,3 } };
+            var sampleSerialization = ComparisonSerializer.SerializeToXml(instance);
+
+            this.serializer.MapType<TypeWithIEnumerableOfPrimitiveTypesProperty>().MapProperty(p => p.ListOfIntegers);
+
+            //ACTION
+            this.serializer.Serialize(writer,instance);
+            var serializedContent = writer.ToString();
+
+            //CHECK
+            serializedContent.Should().Be(sampleSerialization);
+        }
+
     }
 }

--- a/src/MapSerializer.Test/MapXmlSerializerTests.cs
+++ b/src/MapSerializer.Test/MapXmlSerializerTests.cs
@@ -217,5 +217,22 @@ namespace MapSerializer.Test
             //CHECK
             serializedContent.Should().Be(sampleSerialization);
         }
+
+        [Fact]
+        public void MapXmlSerializer_MustSerialize_StringsWithoutSplitThem()
+        {
+            //SETUP
+            var instance = new TypeWithEnumerableOfStringProperty() { ListProperty = new List<string> { "Value 1", "Value 2", "Value 3" } };
+            var sampleSerialization = ComparisonSerializer.SerializeToXml(instance);
+
+            this.serializer.MapType<TypeWithEnumerableOfStringProperty>().MapProperty(p => p.ListProperty);
+
+            //ACTION
+            this.serializer.Serialize(writer,instance);
+            var serializedContent = writer.ToString();
+
+            //CHECK
+            serializedContent.Should().Be(sampleSerialization);
+        }
     }
 }

--- a/src/MapSerializer.Test/Mock/TypeWithEnumerableOfStringProperty.cs
+++ b/src/MapSerializer.Test/Mock/TypeWithEnumerableOfStringProperty.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace MapSerializer.Test.Mock
+{
+    public  class TypeWithEnumerableOfStringProperty
+    {
+        public List<string> ListProperty { get; set; }
+    }
+}

--- a/src/MapSerializer.Test/Mock/TypeWithIEnumerableOfPrimitiveTypesProperty.cs
+++ b/src/MapSerializer.Test/Mock/TypeWithIEnumerableOfPrimitiveTypesProperty.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace MapSerializer.Test.Mock
+{
+    public class TypeWithIEnumerableOfPrimitiveTypesProperty
+    {
+        public List<int> ListOfIntegers { get; set; }
+    }
+}

--- a/src/MapSerializer/MapJsonSerializer.cs
+++ b/src/MapSerializer/MapJsonSerializer.cs
@@ -73,6 +73,10 @@ namespace MapSerializer
                     else
                         writer.Write($"\"{value}\"");
                 }
+                else if (IsPrimitiveEnumerable(propertyInfo.PropertyType))
+                {
+                    SerializePrimitiveEnumerable(writer, value);
+                }
                 else if (IsEnumerable(propertyInfo.PropertyType))
                 {
                     SerializeEnumerable(writer, value);
@@ -94,6 +98,16 @@ namespace MapSerializer
 
             var enumerable = value as IEnumerable;
             enumerable.ForEachAndBetween(item => Serialize(writer, item), () => writer.Write(","));
+
+            writer.Write("]");
+        }
+
+        private void SerializePrimitiveEnumerable(TextWriter writer, object value)
+        {
+            writer.Write("[");
+
+            var enumerable = value as IEnumerable;
+            enumerable.ForEachAndBetween(item => SerializeWithBracket(writer, item), () => writer.Write(","));
 
             writer.Write("]");
         }

--- a/src/MapSerializer/MapJsonSerializer.cs
+++ b/src/MapSerializer/MapJsonSerializer.cs
@@ -36,7 +36,10 @@ namespace MapSerializer
             }
             else
             {
-                writer.Write($"\"{reference}\"");
+                if(IsNumeric(type))
+                    writer.Write($"{reference}");
+                else
+                    writer.Write($"\"{reference}\"");
             }
         }
 

--- a/src/MapSerializer/MapSerializerBase.cs
+++ b/src/MapSerializer/MapSerializerBase.cs
@@ -47,8 +47,11 @@ namespace MapSerializer
 
         internal static bool IsEnumerable(Type type)
         {
-            return typeof(IEnumerable).IsAssignableFrom(type);// ||
-                   //type.GetInterfaces().Contains(typeof(IEnumerable));
+            return typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string);
+        }
+        internal static bool IsPrimitiveEnumerable(Type type)
+        {
+            return IsEnumerable(type) && ( typeof(IEnumerable<string>).IsAssignableFrom(type) ||  typeof(IEnumerable<decimal>).IsAssignableFrom(type) ||  typeof(IEnumerable<DateTime>).IsAssignableFrom(type) );
         }
 
         internal static bool IsNumeric(Type type)

--- a/src/MapSerializer/MapSerializerBase.cs
+++ b/src/MapSerializer/MapSerializerBase.cs
@@ -51,7 +51,11 @@ namespace MapSerializer
         }
         internal static bool IsPrimitiveEnumerable(Type type)
         {
-            return IsEnumerable(type) && ( typeof(IEnumerable<string>).IsAssignableFrom(type) ||  typeof(IEnumerable<decimal>).IsAssignableFrom(type) ||  typeof(IEnumerable<DateTime>).IsAssignableFrom(type) );
+            return IsEnumerable(type) && ( 
+                typeof(IEnumerable<string>).IsAssignableFrom(type)  ||  
+                typeof(IEnumerable<decimal>).IsAssignableFrom(type) ||  
+                typeof(IEnumerable<int>).IsAssignableFrom(type)     ||
+                typeof(IEnumerable<DateTime>).IsAssignableFrom(type));
         }
 
         internal static bool IsNumeric(Type type)

--- a/src/MapSerializer/MapXmlSerializer.cs
+++ b/src/MapSerializer/MapXmlSerializer.cs
@@ -14,13 +14,22 @@ namespace MapSerializer
                 return;
 
             var type = reference.GetType();
-            var typeName = IsNativeType(type) ? type.Name.ToLowerInvariant() : type.Name;
+            var typeName = IsNativeType(type) ? NormalizeName(type) : type.Name;
 
             writer.Write($"<{typeName}>");
 
             SerializeWithoutTypeName(writer, reference);
 
             writer.Write($"</{typeName}>");
+        }
+
+        private static string NormalizeName(Type type)
+        {
+            if(IsNumeric(type))
+            {
+                return type.Name.ToLowerInvariant().Trim('1', '2', '3', '4', '6');
+            }
+            return type.Name.ToLowerInvariant();
         }
 
         private void SerializeWithoutTypeName(TextWriter writer, object reference)

--- a/src/MapSerializer/MapXmlSerializer.cs
+++ b/src/MapSerializer/MapXmlSerializer.cs
@@ -14,12 +14,13 @@ namespace MapSerializer
                 return;
 
             var type = reference.GetType();
+            var typeName = IsNativeType(type) ? type.Name.ToLowerInvariant() : type.Name;
 
-            writer.Write($"<{type.Name}>");
+            writer.Write($"<{typeName}>");
 
             SerializeWithoutTypeName(writer, reference);
 
-            writer.Write($"</{type.Name}>");
+            writer.Write($"</{typeName}>");
         }
 
         private void SerializeWithoutTypeName(TextWriter writer, object reference)


### PR DESCRIPTION
With this PR, MapSerializer can serialize correctly IEnumerable of strings and integers. 
How MapSerialize is treating now:

For XML
```xml
<TypeWithEnumerableOfStringProperty>
   <ListProperty>
      <string>Value 1</string>
      <string>Value 2</string>
      <string>Value 3</string>
    </ListProperty>
</TypeWithEnumerableOfStringProperty>
```

For JSON

```json

{
    "ListProperty": [
        "Value 1",
        "Value 2",
        "Value 3"
    ]
}
```

this PR refs issue #9 
