### PR TITLE
Fix enum serialization

### DIFF
--- a/src/MapSerializer.Test/MapJsonSerializerTests.cs
+++ b/src/MapSerializer.Test/MapJsonSerializerTests.cs
@@ -129,7 +129,7 @@ namespace MapSerializer.Test
         {
             //SETUP
             var instance = new TypeWith1ComplexProperty() { ComplexProperty = new TypeWithStringProperty() { StringProperty = "Value" } };
-            
+
             this.serializer.MapType<TypeWith1ComplexProperty>().MapProperty(p => p.ComplexProperty);
 
             //ACTION
@@ -222,7 +222,7 @@ namespace MapSerializer.Test
             this.serializer.MapType<TypeWithEnumerableOfStringProperty>().MapProperty(p => p.ListProperty);
 
             //ACTION
-            this.serializer.Serialize(writer,instance);
+            this.serializer.Serialize(writer, instance);
             var serializedContent = writer.ToString();
 
             //CHECK
@@ -233,19 +233,34 @@ namespace MapSerializer.Test
         public void MapJsonSerializer_MustSerialize_IEnumerableOfInt()
         {
             //SETUP
-            var instance = new TypeWithIEnumerableOfPrimitiveTypesProperty() { ListOfIntegers = new List<int> { 1,2,3 } };
+            var instance = new TypeWithIEnumerableOfPrimitiveTypesProperty() { ListOfIntegers = new List<int> { 1, 2, 3 } };
             var sampleSerialization = ComparisonSerializer.SerializeToJson(instance);
 
             this.serializer.MapType<TypeWithIEnumerableOfPrimitiveTypesProperty>().MapProperty(p => p.ListOfIntegers);
 
             //ACTION
-            this.serializer.Serialize(writer,instance);
+            this.serializer.Serialize(writer, instance);
             var serializedContent = writer.ToString();
 
             //CHECK
             serializedContent.Should().Be(sampleSerialization);
         }
 
+        [Fact]
+        public void MapJsonSerializer_MustSerialize_Enum()
+        {
+            //SETUP
+            var instance = new TypeWithEnumProperty { EnumProperty = EnumType.Value1 };
+            var sampleSerialization = ComparisonSerializer.SerializeToJson(instance);
+            this.serializer.MapType<TypeWithEnumProperty>().MapProperty(_ => _.EnumProperty);
+
+            //ACTION
+            this.serializer.Serialize(writer, instance);
+            var serializedContent = writer.ToString();
+
+            //CHECK
+            serializedContent.Should().Be(sampleSerialization);
+        }
 
     }
 }

--- a/src/MapSerializer.Test/MapJsonSerializerTests.cs
+++ b/src/MapSerializer.Test/MapJsonSerializerTests.cs
@@ -252,7 +252,7 @@ namespace MapSerializer.Test
             //SETUP
             var instance = new TypeWithEnumProperty { EnumProperty = EnumType.Value1 };
             var sampleSerialization = ComparisonSerializer.SerializeToJson(instance);
-            this.serializer.MapType<TypeWithEnumProperty>().MapProperty(_ => _.EnumProperty);
+            this.serializer.MapType<TypeWithEnumProperty>().MapProperty(p => p.EnumProperty);
 
             //ACTION
             this.serializer.Serialize(writer, instance);

--- a/src/MapSerializer.Test/MapXmlSerializerTests.cs
+++ b/src/MapSerializer.Test/MapXmlSerializerTests.cs
@@ -258,7 +258,7 @@ namespace MapSerializer.Test
             //SETUP
             var instance = new TypeWithEnumProperty { EnumProperty = EnumType.Value1 };
             var sampleSerialization = ComparisonSerializer.SerializeToXml(instance);
-            this.serializer.MapType<TypeWithEnumProperty>().MapProperty(_ => _.EnumProperty);
+            this.serializer.MapType<TypeWithEnumProperty>().MapProperty(p => p.EnumProperty);
 
             //ACTION
             this.serializer.Serialize(writer, instance);

--- a/src/MapSerializer.Test/MapXmlSerializerTests.cs
+++ b/src/MapSerializer.Test/MapXmlSerializerTests.cs
@@ -252,5 +252,21 @@ namespace MapSerializer.Test
             serializedContent.Should().Be(sampleSerialization);
         }
 
+        [Fact]
+        public void MapXmlSerializer_MustSerialize_Enum()
+        {
+            //SETUP
+            var instance = new TypeWithEnumProperty { EnumProperty = EnumType.Value1 };
+            var sampleSerialization = ComparisonSerializer.SerializeToXml(instance);
+            this.serializer.MapType<TypeWithEnumProperty>().MapProperty(_ => _.EnumProperty);
+
+            //ACTION
+            this.serializer.Serialize(writer, instance);
+            var serializedContent = writer.ToString();
+
+            //CHECK
+            serializedContent.Should().Be(sampleSerialization);
+        }
+
     }
 }

--- a/src/MapSerializer.Test/Mock/EnumType.cs
+++ b/src/MapSerializer.Test/Mock/EnumType.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MapSerializer.Test.Mock
+﻿namespace MapSerializer.Test.Mock
 {
-    internal enum EnumType
+    public enum EnumType
     {
         Value1,
         Value2

--- a/src/MapSerializer.Test/Mock/TypeWithEnumProperty.cs
+++ b/src/MapSerializer.Test/Mock/TypeWithEnumProperty.cs
@@ -1,0 +1,7 @@
+﻿namespace MapSerializer.Test.Mock
+{
+    public class TypeWithEnumProperty
+    {
+        public EnumType EnumProperty { get; set; }
+    }
+}

--- a/src/MapSerializer/MapJsonSerializer.cs
+++ b/src/MapSerializer/MapJsonSerializer.cs
@@ -69,12 +69,7 @@ namespace MapSerializer
             {
                 if (IsNativeType(propertyInfo.PropertyType))
                 {
-                    if (IsNumeric(propertyInfo.PropertyType))
-                        writer.Write(value);
-                    else if (IsDateTime(propertyInfo.PropertyType))
-                        writer.Write($"\"{value.ToDateTimeString()}\"");
-                    else
-                        writer.Write($"\"{value}\"");
+                    SerializeNativeType(writer, propertyInfo, value);
                 }
                 else if (IsPrimitiveEnumerable(propertyInfo.PropertyType))
                 {
@@ -93,6 +88,24 @@ namespace MapSerializer
             {
                 writer.Write($"null");
             }
+        }
+
+        private static void SerializeNativeType(TextWriter writer, PropertyInfo propertyInfo, object value)
+        {
+            if (propertyInfo.PropertyType.IsEnum)
+            {
+                writer.Write((int)value);
+            }
+            else if (IsNumeric(propertyInfo.PropertyType))
+            {
+                writer.Write(value);
+            }
+            else if (IsDateTime(propertyInfo.PropertyType))
+            {
+                writer.Write($"\"{value.ToDateTimeString()}\"");
+            }
+            else
+                writer.Write($"\"{value}\"");
         }
 
         private void SerializeEnumerable(TextWriter writer, object value)


### PR DESCRIPTION
Now, enum properties serialization is did the same form that ComparisonSerialize.

Examle:

```json
{"EnumPropery":1}
```
This PR fixes issue #10 